### PR TITLE
docs: show feature flag notation on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ keywords = ["logging", "log", "opentelemetry", "fastrace"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docs"]
+rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 fastrace = ["dep:fastrace"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@
 //!
 //! Read more demos under the [examples](https://github.com/fast/logforth/tree/main/examples) directory.
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 pub mod append;
 pub mod filter;
 pub mod layout;


### PR DESCRIPTION
To build it locally:
```
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features
```

Closes https://github.com/fast/logforth/issues/45