### PR TITLE
chore: set MSRV to 1.75 and update fastrace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ homepage = "https://github.com/fast/logforth"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/fast/logforth"
-rust-version = "1.71.0"
-version = "0.10.0"
+rust-version = "1.75.0"
+version = "0.11.0"
 
 categories = ["development-tools::debugging"]
 keywords = ["logging", "log", "opentelemetry", "fastrace"]
@@ -67,7 +67,7 @@ version = "0.12"
 ## Fastrace dependencies
 [dependencies.fastrace]
 optional = true
-version = "0.6"
+version = "0.7.1"
 
 ## Opentelemetry dependencies
 [dependencies.opentelemetry]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
-[![MSRV 1.71][msrv-badge]](https://www.whatrustisit.com)
+[![MSRV 1.75][msrv-badge]](https://www.whatrustisit.com)
 [![Apache 2.0 licensed][license-badge]][license-url]
 [![Build Status][actions-badge]][actions-url]
 
@@ -64,9 +64,9 @@ Read more demos under the [examples](examples) directory.
 
 Read the online documents at https://docs.rs/logforth.
 
-## Supported Rust Versions (MSRV 1.71)
+## Supported Rust Versions (MSRV 1.75)
 
-Logforth is built against the latest stable release. The minimum supported version is 1.71. The current Logforth version is not guaranteed to build on Rust versions earlier than the minimum supported version.
+Logforth is built against the latest stable release. The minimum supported version is 1.75. The current Logforth version is not guaranteed to build on Rust versions earlier than the minimum supported version.
 
 ## When to release a 1.0 version
 


### PR DESCRIPTION
- **refactor: re-desgin api (#18)**
- **chore: reduce duplicated functions (#20)**
- **docs: add docs and some inplace fixes (#21)**
- **chore: tidy some interfaces and naming (#22)**
- **chore: rename MaxFilter to LevelFilter (#23)**
- **chore: add several badges (#24)**
- **docs: add more content to README (#25)**
- **chore: tidy some code randomly (#26)**
- **feat: opentelemetry appender for HTTP protocols (#27)**
- **fix: avoid param use opentelemetry-otlp type for decoupling (#28)**
- **docs: add more docs (#29)**
- **docs: add keyword, and add docs for rolling file structs**
- **chore: tidy fix toml format**
- **chore: Release logforth version 0.7.3**
- **docs Update README.md**
- **feat: renders kvs in OpentelemetryLog (#31)**
- **feat: allow rolling file at size (#32)**
- **chore: optimize the magic number to Option and extract common code (#33)**
- **test: add unit tests for rolling file (#36)**
- **chore: update crate metadata to reflect the transfer (#37)**
- **ci: ensure msrv work (#38)**
- **chore: add the .idea and .vscode to the gitignore (#39)**
- **refactor: use jiff for timestamp  (#40)**
- **chore: drop unnecessary prefix (#41)**
- **chore: update crate metadata to reflect the transfer (#42)**
- **chore: drop the effectively deprecated author meta field (#43)**
- **feat: add target filter (#44)**
- **feat: support turn off color of TextLayout in code (#48)**
- **fix: FastraceEvent should not hardcode layout (#46)**
- **chore!: revoke pub since we have setters new (#49)**
- **feat: add TargetFilter::level_for_not (#47)**
- **docs: show feature flag notation on docs.rs (#50)**
- **chore: Release logforth version 0.10.0**
- **chore: set MSRV to 1.75 and update fastrace**
