### PR TITLE
feat: display target instead of module_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+* `module_path` is replaced by `target` in `JsonLayout` and `TextLayout` ([#85](https://github.com/fast/logforth/pull/82)).
+
 ## [0.18.1] 2024-11-17
 
 ### New features

--- a/src/layout/json.rs
+++ b/src/layout/json.rs
@@ -87,7 +87,7 @@ pub(crate) struct RecordLine<'a> {
     #[serde(serialize_with = "serialize_time_zone")]
     timestamp: Zoned,
     level: &'a str,
-    module_path: &'a str,
+    target: &'a str,
     file: &'a str,
     line: u32,
     #[serde(serialize_with = "serialize_args")]
@@ -121,7 +121,7 @@ impl JsonLayout {
                 None => Zoned::now(),
             },
             level: record.level().as_str(),
-            module_path: record.module_path().unwrap_or_default(),
+            target: record.target(),
             file: record.file().unwrap_or_default(),
             line: record.line().unwrap_or_default(),
             message: record.args(),

--- a/src/layout/text.rs
+++ b/src/layout/text.rs
@@ -176,12 +176,12 @@ impl TextLayout {
             };
             ColoredString::from(record.level().to_string()).color(color)
         };
-        let module = record.module_path().unwrap_or_default();
+        let target = record.target();
         let file = filename(record);
         let line = record.line().unwrap_or_default();
         let message = record.args();
         let kvs = KvDisplay::new(record.key_values());
-        Ok(format!("{time:.6} {level:>5} {module}: {file}:{line} {message}{kvs}").into_bytes())
+        Ok(format!("{time:.6} {level:>5} {target}: {file}:{line} {message}{kvs}").into_bytes())
     }
 }
 


### PR DESCRIPTION
target is usually identical to target, while target can be manually altered like `log::debug!(target: "request", "handling request")`. And target can be used in envfilter expression like `INFO,request=DEBUG`.