### PR TITLE
fix: increase min version of env_filter to 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ syslog = ["non-blocking", "dep:fasyslog"]
 [dependencies]
 anyhow = { version = "1.0" }
 colored = { version = "2.1" }
-env_filter = { version = "0.1" }
+env_filter = { version = "0.1.1" }
 jiff = { version = "0.1.14" }
 log = { version = "0.4", features = ["std", "kv"] }
 


### PR DESCRIPTION
`env_filter = 0.1.0` will not compile with the follwing errors:

```
error[E0599]: no method named `try_parse` found for struct `env_filter::Builder` in the current scope
   --> src/filter/env_filter.rs:194:17
    |
194 |         builder.try_parse(&config).ok()?;
    |                 ^^^^^^^^^
    |
help: there is a method `parse` with a similar name
    |
194 |         builder.parse(&config).ok()?;
    |                 ~~~~~

error[E0599]: no method named `try_parse` found for struct `env_filter::Builder` in the current scope
   --> src/filter/env_filter.rs:223:16
    |
223 |         self.0.try_parse(filters)?;
    |                ^^^^^^^^^
    |
help: there is a method `parse` with a similar name
    |
223 |         self.0.parse(filters)?;
    |                ~~~~~
```