### PR TITLE
build: try reduce axum deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,17 +241,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,22 +350,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -395,12 +374,6 @@ dependencies = [
  "futures-task",
  "futures-util",
 ]
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
@@ -432,11 +405,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
- "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -614,145 +585,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
-name = "icu_normalizer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
-
-[[package]]
-name = "icu_properties"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locid_transform",
- "icu_properties_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
-
-[[package]]
-name = "icu_provider"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "idna"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,12 +603,6 @@ dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
 ]
-
-[[package]]
-name = "ipnet"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "itertools"
@@ -843,12 +669,6 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "litemap"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lock_api"
@@ -1040,7 +860,6 @@ dependencies = [
  "bytes",
  "http",
  "opentelemetry",
- "reqwest",
  "tracing",
 ]
 
@@ -1058,12 +877,10 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest",
  "serde_json",
  "thiserror",
  "tokio",
  "tonic",
- "tracing",
 ]
 
 [[package]]
@@ -1099,7 +916,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tracing",
 ]
 
 [[package]]
@@ -1356,43 +1172,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "reqwest"
-version = "0.12.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower 0.5.2",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "windows-registry",
-]
-
-[[package]]
 name = "rtrb"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,18 +1279,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,12 +1310,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
 name = "syn"
 version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1564,20 +1325,6 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "tempfile"
@@ -1611,16 +1358,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tinystr"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
-dependencies = [
- "displaydoc",
- "zerovec",
 ]
 
 [[package]]
@@ -1734,7 +1471,6 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper",
- "tokio",
  "tower-layer",
  "tower-service",
 ]
@@ -1795,29 +1531,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
-name = "url"
-version = "2.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
-]
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1855,7 +1568,6 @@ checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
- "rustversion",
  "wasm-bindgen-macro",
 ]
 
@@ -1871,19 +1583,6 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
-dependencies = [
- "cfg-if",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -1919,16 +1618,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1936,36 +1625,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
-dependencies = [
- "windows-result",
- "windows-strings",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2124,42 +1783,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
-name = "writeable"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
-name = "yoke"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2194,49 +1817,6 @@ name = "zerocopy-derive"
 version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06718a168365cad3d5ff0bb133aad346959a2074bd4a85c121255a11304a8626"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,14 +61,16 @@ fastrace = { version = "0.7", optional = true }
 fasyslog = { version = "0.3", optional = true }
 libc = { version = "0.2.162", optional = true }
 native-tls = { version = "0.2", optional = true }
-opentelemetry = { version = "0.28.0", features = ["logs"], optional = true }
-opentelemetry-otlp = { version = "0.28.0", features = [
+opentelemetry = { version = "0.28.0", default-features = false, features = [
+  "logs",
+], optional = true }
+opentelemetry-otlp = { version = "0.28.0", default-features = false, features = [
   "logs",
   "grpc-tonic",
   "http-json",
   "http-proto",
 ], optional = true }
-opentelemetry_sdk = { version = "0.28.0", features = [
+opentelemetry_sdk = { version = "0.28.0", default-features = false, features = [
   "logs",
   "rt-tokio",
 ], optional = true }


### PR DESCRIPTION
```
cargo tree --features=opentelemetry --edges normal
logforth v0.22.0 (/Users/tison/Brittani/logforth)
├── anyhow v1.0.95
├── colored v3.0.0
├── env_filter v0.1.3
│   ├── log v0.4.25
│   └── regex v1.11.1
│       ├── aho-corasick v1.1.3
│       │   └── memchr v2.7.4
│       ├── memchr v2.7.4
│       ├── regex-automata v0.4.9
│       │   ├── aho-corasick v1.1.3 (*)
│       │   ├── memchr v2.7.4
│       │   └── regex-syntax v0.8.5
│       └── regex-syntax v0.8.5
├── jiff v0.2.0
├── log v0.4.25
├── opentelemetry v0.28.0
│   ├── futures-core v0.3.31
│   ├── futures-sink v0.3.31
│   ├── pin-project-lite v0.2.16
│   ├── thiserror v2.0.11
│   │   └── thiserror-impl v2.0.11 (proc-macro)
│   │       ├── proc-macro2 v1.0.93
│   │       │   └── unicode-ident v1.0.16
│   │       ├── quote v1.0.38
│   │       │   └── proc-macro2 v1.0.93 (*)
│   │       └── syn v2.0.98
│   │           ├── proc-macro2 v1.0.93 (*)
│   │           ├── quote v1.0.38 (*)
│   │           └── unicode-ident v1.0.16
│   └── tracing v0.1.41
│       ├── pin-project-lite v0.2.16
│       ├── tracing-attributes v0.1.28 (proc-macro)
│       │   ├── proc-macro2 v1.0.93 (*)
│       │   ├── quote v1.0.38 (*)
│       │   └── syn v2.0.98 (*)
│       └── tracing-core v0.1.33
│           └── once_cell v1.20.3
├── opentelemetry-otlp v0.28.0
│   ├── async-trait v0.1.86 (proc-macro)
│   │   ├── proc-macro2 v1.0.93 (*)
│   │   ├── quote v1.0.38 (*)
│   │   └── syn v2.0.98 (*)
│   ├── futures-core v0.3.31
│   ├── http v1.2.0
│   │   ├── bytes v1.10.0
│   │   ├── fnv v1.0.7
│   │   └── itoa v1.0.14
│   ├── opentelemetry v0.28.0 (*)
│   ├── opentelemetry-http v0.28.0
│   │   ├── async-trait v0.1.86 (proc-macro) (*)
│   │   ├── bytes v1.10.0
│   │   ├── http v1.2.0 (*)
│   │   ├── opentelemetry v0.28.0 (*)
│   │   └── tracing v0.1.41 (*)
│   ├── opentelemetry-proto v0.28.0
│   │   ├── base64 v0.22.1
│   │   ├── hex v0.4.3
│   │   ├── opentelemetry v0.28.0 (*)
│   │   ├── opentelemetry_sdk v0.28.0
│   │   │   ├── async-trait v0.1.86 (proc-macro) (*)
│   │   │   ├── futures-channel v0.3.31
│   │   │   │   └── futures-core v0.3.31
│   │   │   ├── futures-executor v0.3.31
│   │   │   │   ├── futures-core v0.3.31
│   │   │   │   ├── futures-task v0.3.31
│   │   │   │   └── futures-util v0.3.31
│   │   │   │       ├── futures-core v0.3.31
│   │   │   │       ├── futures-macro v0.3.31 (proc-macro)
│   │   │   │       │   ├── proc-macro2 v1.0.93 (*)
│   │   │   │       │   ├── quote v1.0.38 (*)
│   │   │   │       │   └── syn v2.0.98 (*)
│   │   │   │       ├── futures-sink v0.3.31
│   │   │   │       ├── futures-task v0.3.31
│   │   │   │       ├── pin-project-lite v0.2.16
│   │   │   │       ├── pin-utils v0.1.0
│   │   │   │       └── slab v0.4.9
│   │   │   ├── futures-util v0.3.31 (*)
│   │   │   ├── glob v0.3.2
│   │   │   ├── opentelemetry v0.28.0 (*)
│   │   │   ├── percent-encoding v2.3.1
│   │   │   ├── rand v0.8.5
│   │   │   │   ├── libc v0.2.169
│   │   │   │   ├── rand_chacha v0.3.1
│   │   │   │   │   ├── ppv-lite86 v0.2.20
│   │   │   │   │   │   └── zerocopy v0.7.35
│   │   │   │   │   │       ├── byteorder v1.5.0
│   │   │   │   │   │       └── zerocopy-derive v0.7.35 (proc-macro)
│   │   │   │   │   │           ├── proc-macro2 v1.0.93 (*)
│   │   │   │   │   │           ├── quote v1.0.38 (*)
│   │   │   │   │   │           └── syn v2.0.98 (*)
│   │   │   │   │   └── rand_core v0.6.4
│   │   │   │   │       └── getrandom v0.2.15
│   │   │   │   │           ├── cfg-if v1.0.0
│   │   │   │   │           └── libc v0.2.169
│   │   │   │   └── rand_core v0.6.4 (*)
│   │   │   ├── serde_json v1.0.138
│   │   │   │   ├── itoa v1.0.14
│   │   │   │   ├── memchr v2.7.4
│   │   │   │   ├── ryu v1.0.19
│   │   │   │   └── serde v1.0.217
│   │   │   │       └── serde_derive v1.0.217 (proc-macro)
│   │   │   │           ├── proc-macro2 v1.0.93 (*)
│   │   │   │           ├── quote v1.0.38 (*)
│   │   │   │           └── syn v2.0.98 (*)
│   │   │   ├── thiserror v2.0.11 (*)
│   │   │   ├── tokio v1.43.0
│   │   │   │   ├── bytes v1.10.0
│   │   │   │   ├── libc v0.2.169
│   │   │   │   ├── mio v1.0.3
│   │   │   │   │   └── libc v0.2.169
│   │   │   │   ├── pin-project-lite v0.2.16
│   │   │   │   ├── socket2 v0.5.8
│   │   │   │   │   └── libc v0.2.169
│   │   │   │   └── tokio-macros v2.5.0 (proc-macro)
│   │   │   │       ├── proc-macro2 v1.0.93 (*)
│   │   │   │       ├── quote v1.0.38 (*)
│   │   │   │       └── syn v2.0.98 (*)
│   │   │   └── tokio-stream v0.1.17
│   │   │       ├── futures-core v0.3.31
│   │   │       ├── pin-project-lite v0.2.16
│   │   │       └── tokio v1.43.0 (*)
│   │   ├── prost v0.13.5
│   │   │   ├── bytes v1.10.0
│   │   │   └── prost-derive v0.13.5 (proc-macro)
│   │   │       ├── anyhow v1.0.95
│   │   │       ├── itertools v0.14.0
│   │   │       │   └── either v1.13.0
│   │   │       ├── proc-macro2 v1.0.93 (*)
│   │   │       ├── quote v1.0.38 (*)
│   │   │       └── syn v2.0.98 (*)
│   │   ├── serde v1.0.217 (*)
│   │   └── tonic v0.12.3
│   │       ├── async-stream v0.3.6
│   │       │   ├── async-stream-impl v0.3.6 (proc-macro)
│   │       │   │   ├── proc-macro2 v1.0.93 (*)
│   │       │   │   ├── quote v1.0.38 (*)
│   │       │   │   └── syn v2.0.98 (*)
│   │       │   ├── futures-core v0.3.31
│   │       │   └── pin-project-lite v0.2.16
│   │       ├── async-trait v0.1.86 (proc-macro) (*)
│   │       ├── axum v0.7.9
│   │       │   ├── async-trait v0.1.86 (proc-macro) (*)
│   │       │   ├── axum-core v0.4.5
│   │       │   │   ├── async-trait v0.1.86 (proc-macro) (*)
│   │       │   │   ├── bytes v1.10.0
│   │       │   │   ├── futures-util v0.3.31 (*)
│   │       │   │   ├── http v1.2.0 (*)
│   │       │   │   ├── http-body v1.0.1
│   │       │   │   │   ├── bytes v1.10.0
│   │       │   │   │   └── http v1.2.0 (*)
│   │       │   │   ├── http-body-util v0.1.2
│   │       │   │   │   ├── bytes v1.10.0
│   │       │   │   │   ├── futures-util v0.3.31 (*)
│   │       │   │   │   ├── http v1.2.0 (*)
│   │       │   │   │   ├── http-body v1.0.1 (*)
│   │       │   │   │   └── pin-project-lite v0.2.16
│   │       │   │   ├── mime v0.3.17
│   │       │   │   ├── pin-project-lite v0.2.16
│   │       │   │   ├── rustversion v1.0.19 (proc-macro)
│   │       │   │   ├── sync_wrapper v1.0.2
│   │       │   │   ├── tower-layer v0.3.3
│   │       │   │   └── tower-service v0.3.3
│   │       │   ├── bytes v1.10.0
│   │       │   ├── futures-util v0.3.31 (*)
│   │       │   ├── http v1.2.0 (*)
│   │       │   ├── http-body v1.0.1 (*)
│   │       │   ├── http-body-util v0.1.2 (*)
│   │       │   ├── itoa v1.0.14
│   │       │   ├── matchit v0.7.3
│   │       │   ├── memchr v2.7.4
│   │       │   ├── mime v0.3.17
│   │       │   ├── percent-encoding v2.3.1
│   │       │   ├── pin-project-lite v0.2.16
│   │       │   ├── rustversion v1.0.19 (proc-macro)
│   │       │   ├── serde v1.0.217 (*)
│   │       │   ├── sync_wrapper v1.0.2
│   │       │   ├── tower v0.5.2
│   │       │   │   ├── futures-core v0.3.31
│   │       │   │   ├── futures-util v0.3.31 (*)
│   │       │   │   ├── pin-project-lite v0.2.16
│   │       │   │   ├── sync_wrapper v1.0.2
│   │       │   │   ├── tower-layer v0.3.3
│   │       │   │   └── tower-service v0.3.3
│   │       │   ├── tower-layer v0.3.3
│   │       │   └── tower-service v0.3.3
│   │       ├── base64 v0.22.1
│   │       ├── bytes v1.10.0
│   │       ├── h2 v0.4.7
│   │       │   ├── atomic-waker v1.1.2
│   │       │   ├── bytes v1.10.0
│   │       │   ├── fnv v1.0.7
│   │       │   ├── futures-core v0.3.31
│   │       │   ├── futures-sink v0.3.31
│   │       │   ├── http v1.2.0 (*)
│   │       │   ├── indexmap v2.7.1
│   │       │   │   ├── equivalent v1.0.1
│   │       │   │   └── hashbrown v0.15.2
│   │       │   ├── slab v0.4.9
│   │       │   ├── tokio v1.43.0 (*)
│   │       │   ├── tokio-util v0.7.13
│   │       │   │   ├── bytes v1.10.0
│   │       │   │   ├── futures-core v0.3.31
│   │       │   │   ├── futures-sink v0.3.31
│   │       │   │   ├── pin-project-lite v0.2.16
│   │       │   │   └── tokio v1.43.0 (*)
│   │       │   └── tracing v0.1.41 (*)
│   │       ├── http v1.2.0 (*)
│   │       ├── http-body v1.0.1 (*)
│   │       ├── http-body-util v0.1.2 (*)
│   │       ├── hyper v1.6.0
│   │       │   ├── bytes v1.10.0
│   │       │   ├── futures-channel v0.3.31 (*)
│   │       │   ├── futures-util v0.3.31 (*)
│   │       │   ├── h2 v0.4.7 (*)
│   │       │   ├── http v1.2.0 (*)
│   │       │   ├── http-body v1.0.1 (*)
│   │       │   ├── httparse v1.10.0
│   │       │   ├── httpdate v1.0.3
│   │       │   ├── itoa v1.0.14
│   │       │   ├── pin-project-lite v0.2.16
│   │       │   ├── smallvec v1.13.2
│   │       │   ├── tokio v1.43.0 (*)
│   │       │   └── want v0.3.1
│   │       │       └── try-lock v0.2.5
│   │       ├── hyper-timeout v0.5.2
│   │       │   ├── hyper v1.6.0 (*)
│   │       │   ├── hyper-util v0.1.10
│   │       │   │   ├── bytes v1.10.0
│   │       │   │   ├── futures-channel v0.3.31 (*)
│   │       │   │   ├── futures-util v0.3.31 (*)
│   │       │   │   ├── http v1.2.0 (*)
│   │       │   │   ├── http-body v1.0.1 (*)
│   │       │   │   ├── hyper v1.6.0 (*)
│   │       │   │   ├── pin-project-lite v0.2.16
│   │       │   │   ├── socket2 v0.5.8 (*)
│   │       │   │   ├── tokio v1.43.0 (*)
│   │       │   │   ├── tower-service v0.3.3
│   │       │   │   └── tracing v0.1.41 (*)
│   │       │   ├── pin-project-lite v0.2.16
│   │       │   ├── tokio v1.43.0 (*)
│   │       │   └── tower-service v0.3.3
│   │       ├── hyper-util v0.1.10 (*)
│   │       ├── percent-encoding v2.3.1
│   │       ├── pin-project v1.1.9
│   │       │   └── pin-project-internal v1.1.9 (proc-macro)
│   │       │       ├── proc-macro2 v1.0.93 (*)
│   │       │       ├── quote v1.0.38 (*)
│   │       │       └── syn v2.0.98 (*)
│   │       ├── prost v0.13.5 (*)
│   │       ├── socket2 v0.5.8 (*)
│   │       ├── tokio v1.43.0 (*)
│   │       ├── tokio-stream v0.1.17 (*)
│   │       ├── tower v0.4.13
│   │       │   ├── futures-core v0.3.31
│   │       │   ├── futures-util v0.3.31 (*)
│   │       │   ├── indexmap v1.9.3
│   │       │   │   └── hashbrown v0.12.3
│   │       │   ├── pin-project v1.1.9 (*)
│   │       │   ├── pin-project-lite v0.2.16
│   │       │   ├── rand v0.8.5 (*)
│   │       │   ├── slab v0.4.9
│   │       │   ├── tokio v1.43.0 (*)
│   │       │   ├── tokio-util v0.7.13 (*)
│   │       │   ├── tower-layer v0.3.3
│   │       │   ├── tower-service v0.3.3
│   │       │   └── tracing v0.1.41 (*)
│   │       ├── tower-layer v0.3.3
│   │       ├── tower-service v0.3.3
│   │       └── tracing v0.1.41 (*)
│   ├── opentelemetry_sdk v0.28.0 (*)
│   ├── prost v0.13.5 (*)
│   ├── serde_json v1.0.138 (*)
│   ├── thiserror v2.0.11 (*)
│   ├── tokio v1.43.0 (*)
│   └── tonic v0.12.3 (*)
└── opentelemetry_sdk v0.28.0 (*)
```