### PR TITLE
feat: Support Google structured logging format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
           cargo run --no-default-features --example simple_stdout
           cargo run --features="json" --example json_stdout
           cargo run --features="json,rolling-file" --example rolling_file
+          cargo run --features="fastrace/enable,google_structured_log" --example google_structured_log
           cargo run --features="fastrace/enable" --example fastrace
 
   required:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,6 +796,10 @@ name = "log"
 version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+dependencies = [
+ "serde",
+ "value-bag",
+]
 
 [[package]]
 name = "logforth"
@@ -1406,6 +1420,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_fmt"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d4ddca14104cd60529e8c7f7ba71a2c8acd8f7f5cfcdc2faf97eeb7c3010a4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1471,6 +1494,84 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "sval"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cc9739f56c5d0c44a5ed45473ec868af02eb896af8c05f616673a31e1d1bb09"
+
+[[package]]
+name = "sval_buffer"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f39b07436a8c271b34dad5070c634d1d3d76d6776e938ee97b4a66a5e8003d0b"
+dependencies = [
+ "sval",
+ "sval_ref",
+]
+
+[[package]]
+name = "sval_dynamic"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffcb072d857431bf885580dacecf05ed987bac931230736739a79051dbf3499b"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_fmt"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f214f427ad94a553e5ca5514c95c6be84667cbc5568cce957f03f3477d03d5c"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_json"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ed34b32e638dec9a99c8ac92d0aa1220d40041026b625474c2b6a4d6f4feb"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_nested"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14bae8fcb2f24fee2c42c1f19037707f7c9a29a0cda936d2188d48a961c4bb2a"
+dependencies = [
+ "sval",
+ "sval_buffer",
+ "sval_ref",
+]
+
+[[package]]
+name = "sval_ref"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4eaea3821d3046dcba81d4b8489421da42961889902342691fb7eab491d79e"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_serde"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "172dd4aa8cb3b45c8ac8f3b4111d644cd26938b0643ede8f93070812b87fb339"
+dependencies = [
+ "serde",
+ "sval",
+ "sval_nested",
+]
 
 [[package]]
 name = "syn"
@@ -1696,6 +1797,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1723,6 +1830,42 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "value-bag"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
+dependencies = [
+ "value-bag-serde1",
+ "value-bag-sval2",
+]
+
+[[package]]
+name = "value-bag-serde1"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35540706617d373b118d550d41f5dfe0b78a0c195dc13c6815e92e2638432306"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "serde_fmt",
+]
+
+[[package]]
+name = "value-bag-sval2"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe7e140a2658cc16f7ee7a86e413e803fc8f9b5127adc8755c19f9fefa63a52"
+dependencies = [
+ "sval",
+ "sval_buffer",
+ "sval_dynamic",
+ "sval_fmt",
+ "sval_json",
+ "sval_ref",
+ "sval_serde",
+]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,16 +189,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "erased-serde"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
-dependencies = [
- "serde",
- "typeid",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,10 +786,6 @@ name = "log"
 version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
-dependencies = [
- "serde",
- "value-bag",
-]
 
 [[package]]
 name = "logforth"
@@ -1420,15 +1406,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_fmt"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d4ddca14104cd60529e8c7f7ba71a2c8acd8f7f5cfcdc2faf97eeb7c3010a4"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_json"
 version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,84 +1471,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "sval"
-version = "2.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc9739f56c5d0c44a5ed45473ec868af02eb896af8c05f616673a31e1d1bb09"
-
-[[package]]
-name = "sval_buffer"
-version = "2.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f39b07436a8c271b34dad5070c634d1d3d76d6776e938ee97b4a66a5e8003d0b"
-dependencies = [
- "sval",
- "sval_ref",
-]
-
-[[package]]
-name = "sval_dynamic"
-version = "2.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffcb072d857431bf885580dacecf05ed987bac931230736739a79051dbf3499b"
-dependencies = [
- "sval",
-]
-
-[[package]]
-name = "sval_fmt"
-version = "2.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f214f427ad94a553e5ca5514c95c6be84667cbc5568cce957f03f3477d03d5c"
-dependencies = [
- "itoa",
- "ryu",
- "sval",
-]
-
-[[package]]
-name = "sval_json"
-version = "2.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ed34b32e638dec9a99c8ac92d0aa1220d40041026b625474c2b6a4d6f4feb"
-dependencies = [
- "itoa",
- "ryu",
- "sval",
-]
-
-[[package]]
-name = "sval_nested"
-version = "2.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14bae8fcb2f24fee2c42c1f19037707f7c9a29a0cda936d2188d48a961c4bb2a"
-dependencies = [
- "sval",
- "sval_buffer",
- "sval_ref",
-]
-
-[[package]]
-name = "sval_ref"
-version = "2.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4eaea3821d3046dcba81d4b8489421da42961889902342691fb7eab491d79e"
-dependencies = [
- "sval",
-]
-
-[[package]]
-name = "sval_serde"
-version = "2.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "172dd4aa8cb3b45c8ac8f3b4111d644cd26938b0643ede8f93070812b87fb339"
-dependencies = [
- "serde",
- "sval",
- "sval_nested",
-]
 
 [[package]]
 name = "syn"
@@ -1797,12 +1696,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "typeid"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1830,42 +1723,6 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
-name = "value-bag"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
-dependencies = [
- "value-bag-serde1",
- "value-bag-sval2",
-]
-
-[[package]]
-name = "value-bag-serde1"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35540706617d373b118d550d41f5dfe0b78a0c195dc13c6815e92e2638432306"
-dependencies = [
- "erased-serde",
- "serde",
- "serde_fmt",
-]
-
-[[package]]
-name = "value-bag-sval2"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe7e140a2658cc16f7ee7a86e413e803fc8f9b5127adc8755c19f9fefa63a52"
-dependencies = [
- "sval",
- "sval_buffer",
- "sval_dynamic",
- "sval_fmt",
- "sval_json",
- "sval_ref",
- "sval_serde",
-]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,10 +32,11 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = []
+default = ["google_structured_log"]
 
 colored = ["dep:colored"]
 fastrace = ["dep:fastrace"]
+google_structured_log = ["json", "log/kv_serde"]
 journald = ["dep:libc"]
 json = ["dep:serde_json", "dep:serde", "jiff/serde"]
 native-tls = ["dep:native-tls", "fasyslog?/native-tls"]
@@ -126,3 +127,9 @@ doc-scrape-examples = true
 name = "fastrace"
 path = "examples/fastrace.rs"
 required-features = ["fastrace", "fastrace/enable"]
+
+[[example]]
+doc-scrape-examples = true
+name = "google_structured_log"
+path = "examples/google_structured_log.rs"
+required-features = ["fastrace", "fastrace/enable", "google_structured_log"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,10 +129,10 @@ required-features = ["journald"]
 doc-scrape-examples = true
 name = "fastrace"
 path = "examples/fastrace.rs"
-required-features = ["fastrace", "fastrace/enable"]
+required-features = ["fastrace/enable"]
 
 [[example]]
 doc-scrape-examples = true
 name = "google_structured_log"
 path = "examples/google_structured_log.rs"
-required-features = ["fastrace", "fastrace/enable", "google_structured_log"]
+required-features = ["fastrace/enable", "google_structured_log"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,11 +32,11 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["google_structured_log"]
+default = []
 
 colored = ["dep:colored"]
 fastrace = ["dep:fastrace"]
-google_structured_log = ["json", "log/kv_serde"]
+google_structured_log = ["dep:serde_json", "dep:serde", "jiff/serde"]
 journald = ["dep:libc"]
 json = ["dep:serde_json", "dep:serde", "jiff/serde"]
 native-tls = ["dep:native-tls", "fasyslog?/native-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,9 @@ default = []
 
 colored = ["dep:colored"]
 fastrace = ["dep:fastrace"]
-google_structured_log = ["dep:serde_json", "dep:serde", "jiff/serde"]
+google_structured_log = ["internal-serde", "dep:serde_json"]
 journald = ["dep:libc"]
-json = ["dep:serde_json", "dep:serde", "jiff/serde"]
+json = ["internal-serde", "dep:serde_json"]
 native-tls = ["dep:native-tls", "fasyslog?/native-tls"]
 non-blocking = ["dep:crossbeam-channel"]
 opentelemetry = [
@@ -48,6 +48,9 @@ opentelemetry = [
 ]
 rolling-file = ["non-blocking"]
 syslog = ["non-blocking", "dep:fasyslog"]
+
+# Internal features - not intended for directly public use
+internal-serde = ["dep:serde", "log/kv_serde", "jiff/serde"]
 
 [dependencies]
 anyhow = { version = "1.0" }

--- a/examples/google_structured_log.rs
+++ b/examples/google_structured_log.rs
@@ -1,0 +1,66 @@
+// Copyright 2025 FastLabs Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use fastrace::collector::Config;
+use fastrace::collector::ConsoleReporter;
+use fastrace::collector::SpanContext;
+use fastrace::prelude::{SpanId, TraceId};
+use fastrace::Span;
+use logforth::layout::GoogleStructuredLogLayout;
+use logforth::{append, diagnostic};
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct NestedStructuredValue {
+    c: String,
+    d: bool,
+}
+
+#[derive(Serialize)]
+struct MyStructuredValue {
+    a: i32,
+    b: NestedStructuredValue,
+}
+
+fn main() {
+    logforth::builder()
+        .dispatch(|d| {
+            d.diagnostic(diagnostic::FastraceDiagnostic::default())
+                .append(
+                    append::Stdout::default().with_layout(
+                        GoogleStructuredLogLayout::default()
+                            .trace_project_id("project-id")
+                            .label_keys(["label1"]),
+                    ),
+                )
+        })
+        .apply();
+
+    fastrace::set_reporter(ConsoleReporter, Config::default());
+
+    {
+        let root = Span::root("root", SpanContext::new(TraceId::random(), SpanId(0)));
+        let _g = root.set_local_parent();
+
+        let structured_value = MyStructuredValue {
+            a: 1,
+            b: NestedStructuredValue {
+                c: "Hello".into(),
+                d: true,
+            },
+        };
+
+        log::info!(label1="this is a label value", notLabel:serde=structured_value; "Hello label value!");
+    }
+}

--- a/examples/google_structured_log.rs
+++ b/examples/google_structured_log.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 FastLabs Developers
+// Copyright 2024 FastLabs Developers
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,10 +15,12 @@
 use fastrace::collector::Config;
 use fastrace::collector::ConsoleReporter;
 use fastrace::collector::SpanContext;
-use fastrace::prelude::{SpanId, TraceId};
+use fastrace::prelude::SpanId;
+use fastrace::prelude::TraceId;
 use fastrace::Span;
+use logforth::append;
+use logforth::diagnostic;
 use logforth::layout::GoogleStructuredLogLayout;
-use logforth::{append, diagnostic};
 use serde::Serialize;
 
 #[derive(Serialize)]

--- a/examples/google_structured_log.rs
+++ b/examples/google_structured_log.rs
@@ -63,6 +63,10 @@ fn main() {
             },
         };
 
-        log::info!(label1="this is a label value", notLabel:serde=structured_value; "Hello label value!");
+        log::info!(
+            label1 = "this is a label value",
+            notLabel:serde = structured_value;
+            "Hello label value!",
+        );
     }
 }

--- a/src/layout/google_structured_log.rs
+++ b/src/layout/google_structured_log.rs
@@ -1,0 +1,250 @@
+// Copyright 2025 FastLabs Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::borrow::Cow;
+use std::collections::{BTreeMap, HashSet};
+use std::fmt::Arguments;
+
+use crate::diagnostic::Visitor;
+use crate::layout::Layout;
+use crate::Diagnostic;
+use jiff::Timestamp;
+use log::Record;
+use serde::Serialize;
+use serde_json::Value;
+
+/// A layout for Google Cloud structured JSON logging.
+///
+/// See the [Google documentation](https://cloud.google.com/logging/docs/structured-logging) for more
+/// information about the structure of the format.
+///
+/// Example format:
+/// ```json
+/// {"severity":"INFO","timestamp":"2025-04-02T10:34:33.225602Z","message":"Hello label value!","logging.googleapis.com/labels":{"label1":"this is a label value"},"logging.googleapis.com/trace":"projects/project-id/traces/612b91406b684ece2c4137ce0f3fd668", "logging.googleapis.com/sourceLocation":{"file":"examples/google_structured_log.rs","line":64,"function":"google_structured_log"}}
+/// ```
+///
+/// If the trace project ID is set, a few keys are treated specially:
+/// - `trace_id`: Combined with trace project ID, set as the `logging.googleapis.com/trace` field.
+/// - `span_id`: Set as the `logging.googleapis.com/spanId` field.
+/// - `trace_sampled`: Set as the `logging.googleapis.com/trace_sampled` field.
+///
+/// Information may be stored either in the payload, or as labels. The payload allows a structured
+/// value to be stored, but is not indexed by default. Labels are indexed by default, but can only
+/// store strings.
+///
+/// # Examples
+///
+/// ```
+/// use logforth::layout::GoogleStructuredLogLayout;
+///
+/// let structured_json_layout = GoogleStructuredLogLayout::default();
+/// ```
+#[derive(Default, Debug, Clone)]
+pub struct GoogleStructuredLogLayout {
+    trace_project_id: Option<String>,
+    label_keys: Option<HashSet<String>>,
+}
+
+impl GoogleStructuredLogLayout {
+    /// Sets the trace project ID for traces.
+    ///
+    /// If set, the trace_id, span_id, and trace_sampled fields will be set in the log record, in such
+    /// a way that they can be linked to traces in the Google Cloud Trace service.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use logforth::layout::GoogleStructuredLogLayout;
+    ///
+    /// let structured_json_layout = GoogleStructuredLogLayout::default().trace_project_id("project-id");
+    /// ```
+    pub fn trace_project_id(mut self, project_id: impl Into<String>) -> Self {
+        self.trace_project_id = Some(project_id.into());
+        self
+    }
+
+    /// Sets the set of keys that should be treated as labels.
+    ///
+    /// Any key found in a log entry, and referenced here, will be stored in the labels field rather than
+    /// the payload. Labels are indexed by default, but can only store strings.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use logforth::layout::GoogleStructuredLogLayout;
+    ///
+    /// let structured_json_layout = GoogleStructuredLogLayout::default().label_keys(["label1", "label2"]);
+    /// ```
+    pub fn label_keys(mut self, label_keys: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.label_keys = Some(label_keys.into_iter().map(Into::into).collect());
+        self
+    }
+}
+
+struct KvCollector<'a> {
+    trace_project_id: Option<&'a str>,
+    label_keys: Option<&'a HashSet<String>>,
+    payload_fields: &'a mut BTreeMap<Cow<'a, str>, Value>,
+    labels: &'a mut BTreeMap<Cow<'a, str>, Cow<'a, str>>,
+    trace: &'a mut Option<String>,
+    span_id: &'a mut Option<String>,
+    trace_sampled: &'a mut Option<bool>,
+}
+
+impl<'kvs> log::kv::VisitSource<'kvs> for KvCollector<'kvs> {
+    fn visit_pair(
+        &mut self,
+        key: log::kv::Key<'kvs>,
+        value: log::kv::Value<'kvs>,
+    ) -> Result<(), log::kv::Error> {
+        let k = key
+            .to_borrowed_str()
+            .map_or_else(|| key.to_string().into(), Cow::Borrowed);
+
+        if self
+            .label_keys
+            .as_ref()
+            .map_or(false, |keys| keys.contains(k.as_ref()))
+        {
+            self.labels.insert(k, value.to_string().into());
+        } else {
+            self.payload_fields.insert(
+                k,
+                serde_json::to_value(&value).unwrap_or(value.to_string().into()),
+            );
+        }
+
+        Ok(())
+    }
+}
+
+impl Visitor for KvCollector<'_> {
+    fn visit(&mut self, key: Cow<str>, value: Cow<str>) {
+        if let Some(trace_project_id) = self.trace_project_id.as_ref() {
+            if key == "trace_id" {
+                *self.trace = Some(format!("projects/{}/traces/{}", trace_project_id, value));
+                return;
+            }
+
+            if key == "span_id" {
+                *self.span_id = Some(value.into_owned());
+                return;
+            }
+
+            if key == "trace_sampled" {
+                if let Some(v) = value.parse().ok() {
+                    *self.trace_sampled = Some(v);
+                }
+                return;
+            }
+        }
+
+        if self
+            .label_keys
+            .as_ref()
+            .map_or(false, |keys| keys.contains(value.as_ref()))
+        {
+            self.labels
+                .insert(key.into_owned().into(), value.into_owned().into());
+        } else {
+            self.payload_fields
+                .insert(key.into_owned().into(), value.into_owned().into());
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct SourceLocation<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    file: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    line: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    function: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct RecordLine<'a> {
+    #[serde(flatten)]
+    extra_fields: &'a BTreeMap<Cow<'a, str>, Value>,
+    severity: &'a str,
+    timestamp: Timestamp,
+    #[serde(serialize_with = "serialize_args")]
+    message: &'a Arguments<'a>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    #[serde(rename = "logging.googleapis.com/labels")]
+    labels: &'a BTreeMap<Cow<'a, str>, Cow<'a, str>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "logging.googleapis.com/trace")]
+    trace: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "logging.googleapis.com/spanId")]
+    span_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "logging.googleapis.com/trace_sampled")]
+    trace_sampled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "logging.googleapis.com/sourceLocation")]
+    source_location: Option<SourceLocation<'a>>,
+}
+
+fn serialize_args<S>(args: &Arguments, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.collect_str(args)
+}
+
+impl Layout for GoogleStructuredLogLayout {
+    fn format(
+        &self,
+        record: &Record,
+        diagnostics: &[Box<dyn Diagnostic>],
+    ) -> anyhow::Result<Vec<u8>> {
+        let mut payload_fields = BTreeMap::new();
+        let mut labels = BTreeMap::new();
+        let mut visitor = KvCollector {
+            trace_project_id: self.trace_project_id.as_deref(),
+            label_keys: self.label_keys.as_ref(),
+            payload_fields: &mut payload_fields,
+            labels: &mut labels,
+            trace: &mut None,
+            span_id: &mut None,
+            trace_sampled: &mut None,
+        };
+
+        record.key_values().visit(&mut visitor)?;
+        for d in diagnostics {
+            d.visit(&mut visitor);
+        }
+
+        let record_line = RecordLine {
+            extra_fields: visitor.payload_fields,
+            timestamp: Timestamp::now(),
+            severity: record.level().as_str(),
+            message: record.args(),
+            labels: visitor.labels,
+            trace: visitor.trace.as_deref(),
+            span_id: visitor.span_id.as_deref(),
+            trace_sampled: visitor.trace_sampled.clone(),
+            source_location: Some(SourceLocation {
+                file: record.file(),
+                line: record.line(),
+                function: record.module_path(),
+            }),
+        };
+
+        Ok(serde_json::to_vec(&record_line)?)
+    }
+}

--- a/src/layout/json.rs
+++ b/src/layout/json.rs
@@ -78,9 +78,11 @@ impl<'kvs> log::kv::VisitSource<'kvs> for KvCollector<'_> {
         key: log::kv::Key<'kvs>,
         value: log::kv::Value<'kvs>,
     ) -> Result<(), log::kv::Error> {
-        let k = key.to_string();
-        let v = value.to_string();
-        self.kvs.insert(k, v.into());
+        let key = key.to_string();
+        match serde_json::to_value(&value) {
+            Ok(value) => self.kvs.insert(key, value),
+            Err(_) => self.kvs.insert(key, value.to_string().into()),
+        };
         Ok(())
     }
 }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -18,6 +18,11 @@ use std::fmt;
 
 use crate::Diagnostic;
 
+#[cfg(feature = "google_structured_log")]
+mod google_structured_log;
+#[cfg(feature = "google_structured_log")]
+pub use google_structured_log::GoogleStructuredLogLayout;
+
 #[cfg(feature = "json")]
 mod json;
 #[cfg(feature = "json")]


### PR DESCRIPTION
Implements a layout for Google's structured logging format.

Uses the `log_serde` feature of `log` to encode arbitrary serializable types into the JSON payload.

Fixes #99 