### PR TITLE
revert: blocking rolling file and syslog appender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Breaking changes
 
-* `Diagnosic` is now a trait. `Visitor`'s method signature is simplified.
+* `Diagnostic` is now a trait. `Visitor`'s method signature is simplified.
 * `Append::flush` is now fallible.
-
-### New features
-
-* Add `BlockingRollingFile` and `BlockingSyslog` appenders. They would lock the inner appender and log synchronously. In some lower rate logging scenarios, this would be more efficient than the non-blocking version.
 
 ## [0.23.1] 2025-03-23
 

--- a/src/append/mod.rs
+++ b/src/append/mod.rs
@@ -37,13 +37,9 @@ pub use self::journald::Journald;
 #[cfg(feature = "opentelemetry")]
 pub use self::opentelemetry::OpentelemetryLog;
 #[cfg(feature = "rolling-file")]
-pub use self::rolling_file::BlockingRollingFile;
-#[cfg(feature = "rolling-file")]
 pub use self::rolling_file::RollingFile;
 pub use self::stdio::Stderr;
 pub use self::stdio::Stdout;
-#[cfg(feature = "syslog")]
-pub use self::syslog::BlockingSyslog;
 #[cfg(feature = "syslog")]
 pub use self::syslog::Syslog;
 

--- a/src/append/rolling_file/mod.rs
+++ b/src/append/rolling_file/mod.rs
@@ -41,7 +41,6 @@
 //! log::info!("This log will be written to a rolling file.");
 //! ```
 
-pub use append::BlockingRollingFile;
 pub use append::RollingFile;
 pub use rolling::RollingFileWriter;
 pub use rolling::RollingFileWriterBuilder;


### PR DESCRIPTION
After a discussion with @andylokandy I realize that the blocking impl looks "premature optimization" and even unsure whether an optimization at all. Reverted.