### PR TITLE
fix: render trace_id and span_id for FastraceDiagnostic

### DIFF
--- a/src/diagnostic/fastrace.rs
+++ b/src/diagnostic/fastrace.rs
@@ -42,8 +42,8 @@ pub struct FastraceDiagnostic {}
 impl Diagnostic for FastraceDiagnostic {
     fn visit(&self, visitor: &mut dyn Visitor) -> anyhow::Result<()> {
         if let Some(span) = fastrace::collector::SpanContext::current_local_parent() {
-            let trace_id = format!("{:016x}", span.trace_id.0);
-            visitor.visit("trace_id".into(), trace_id.into())?;
+            visitor.visit("trace_id".into(), span.trace_id.to_string().into())?;
+            visitor.visit("span_id".into(), span.span_id.to_string().into())?;
         }
 
         Ok(())


### PR DESCRIPTION
Closes https://github.com/fast/logforth/issues/127
Related https://github.com/fast/logforth/issues/119