### PR TITLE
chore: otel append build is now infallible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+      - name: Delete rust-toolchain.toml
+        run: rm rust-toolchain.toml
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Breaking changes
+
+* `OpenTelemetryLogBuild::build` is now infallible.
+
 ## [0.25.0] 2025-05-15
 
 ### Breaking changes

--- a/src/append/opentelemetry.rs
+++ b/src/append/opentelemetry.rs
@@ -48,7 +48,8 @@ impl OpentelemetryLogBuilder {
     ///
     /// ```
     /// use logforth::append::opentelemetry::OpentelemetryLogBuilder;
-    /// use opentelemetry_otlp::{LogExporter, WithExportConfig};
+    /// use opentelemetry_otlp::LogExporter;
+    /// use opentelemetry_otlp::WithExportConfig;
     ///
     /// let log_exporter = LogExporter::builder()
     ///     .with_http()
@@ -72,7 +73,8 @@ impl OpentelemetryLogBuilder {
     ///
     /// ```
     /// use logforth::append::opentelemetry::OpentelemetryLogBuilder;
-    /// use opentelemetry_otlp::{LogExporter, WithExportConfig};
+    /// use opentelemetry_otlp::LogExporter;
+    /// use opentelemetry_otlp::WithExportConfig;
     ///
     /// let log_exporter = LogExporter::builder()
     ///     .with_http()
@@ -97,7 +99,8 @@ impl OpentelemetryLogBuilder {
     ///
     /// ```
     /// use logforth::append::opentelemetry::OpentelemetryLogBuilder;
-    /// use opentelemetry_otlp::{LogExporter, WithExportConfig};
+    /// use opentelemetry_otlp::LogExporter;
+    /// use opentelemetry_otlp::WithExportConfig;
     ///
     /// let log_exporter = LogExporter::builder()
     ///     .with_http()
@@ -124,7 +127,8 @@ impl OpentelemetryLogBuilder {
     /// ```
     /// use logforth::append::opentelemetry::OpentelemetryLogBuilder;
     /// use logforth::layout::JsonLayout;
-    /// use opentelemetry_otlp::{LogExporter, WithExportConfig};
+    /// use opentelemetry_otlp::LogExporter;
+    /// use opentelemetry_otlp::WithExportConfig;
     ///
     /// let log_exporter = LogExporter::builder()
     ///     .with_http()
@@ -145,7 +149,8 @@ impl OpentelemetryLogBuilder {
     ///
     /// ```
     /// use logforth::append::opentelemetry::OpentelemetryLogBuilder;
-    /// use opentelemetry_otlp::{LogExporter, WithExportConfig};
+    /// use opentelemetry_otlp::LogExporter;
+    /// use opentelemetry_otlp::WithExportConfig;
     ///
     /// let log_exporter = LogExporter::builder()
     ///     .with_http()
@@ -153,9 +158,9 @@ impl OpentelemetryLogBuilder {
     ///     .build()
     ///     .unwrap();
     /// let builder = OpentelemetryLogBuilder::new("my_service", log_exporter);
-    /// let otlp_appender = builder.build().unwrap();
+    /// let otlp_appender = builder.build();
     /// ```
-    pub fn build(self) -> Result<OpentelemetryLog, opentelemetry_otlp::ExporterBuildError> {
+    pub fn build(self) -> OpentelemetryLog {
         let OpentelemetryLogBuilder {
             name,
             log_exporter,
@@ -177,12 +182,14 @@ impl OpentelemetryLogBuilder {
             .build();
 
         let library = InstrumentationScope::builder(name).build();
+
         let logger = provider.logger_with_scope(library);
-        Ok(OpentelemetryLog {
+
+        OpentelemetryLog {
             layout,
             logger,
             provider,
-        })
+        }
     }
 }
 
@@ -192,17 +199,15 @@ impl OpentelemetryLogBuilder {
 ///
 /// ```
 /// use logforth::append::opentelemetry::OpentelemetryLogBuilder;
-/// use opentelemetry_otlp::{LogExporter, WithExportConfig};
+/// use opentelemetry_otlp::LogExporter;
+/// use opentelemetry_otlp::WithExportConfig;
 ///
 /// let log_exporter = LogExporter::builder()
 ///     .with_http()
 ///     .with_endpoint("http://localhost:4317")
 ///     .build()
 ///     .unwrap();
-/// let otlp_appender =
-///     OpentelemetryLogBuilder::new("service_name", log_exporter)
-///         .build()
-///         .unwrap();
+/// let otlp_appender = OpentelemetryLogBuilder::new("service_name", log_exporter).build();
 /// ```
 #[derive(Debug)]
 pub struct OpentelemetryLog {


### PR DESCRIPTION
This follows up https://github.com/fast/logforth/pull/126