### PR TITLE
feat: Adding Test appender 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,11 @@ tempfile = { version = "3.16" }
 
 [[example]]
 doc-scrape-examples = true
+name = "in_tests"
+path = "examples/in_tests.rs"
+
+[[example]]
+doc-scrape-examples = true
 name = "simple_stdout"
 path = "examples/simple_stdout.rs"
 

--- a/examples/in_tests.rs
+++ b/examples/in_tests.rs
@@ -1,0 +1,36 @@
+// Copyright 2024 FastLabs Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+fn main() {
+    println!("Run this example with `cargo test --package logforth --example in_tests --features append-single-file -- tests --show-output`; compare the output without `--show-output`");
+}
+
+#[cfg(test)]
+mod tests {
+    use logforth::append::Test;
+
+    #[test]
+    fn test_with_logging() {
+        logforth::builder()
+            .dispatch(|d| d.filter(log::LevelFilter::Trace).append(Test::default()))
+            .apply();
+
+        log::error!("Hello error!");
+        log::warn!("Hello warn!");
+        log::info!("Hello info!");
+        log::debug!("Hello debug!");
+        log::trace!("Hello trace!");
+
+        assert!(true);
+    }
+}

--- a/src/append/mod.rs
+++ b/src/append/mod.rs
@@ -31,6 +31,7 @@ pub mod single_file;
 mod stdio;
 #[cfg(feature = "append-syslog")]
 pub mod syslog;
+mod testing;
 
 #[cfg(feature = "append-fastrace")]
 pub use self::fastrace::FastraceEvent;
@@ -46,6 +47,7 @@ pub use self::stdio::Stderr;
 pub use self::stdio::Stdout;
 #[cfg(feature = "append-syslog")]
 pub use self::syslog::Syslog;
+pub use self::testing::Test;
 
 /// A trait representing an appender that can process log records.
 pub trait Append: fmt::Debug + Send + Sync + 'static {

--- a/src/append/testing.rs
+++ b/src/append/testing.rs
@@ -1,0 +1,73 @@
+// Copyright 2024 FastLabs Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use log::Record;
+
+use crate::append::Append;
+use crate::layout::TextLayout;
+use crate::Diagnostic;
+use crate::Layout;
+
+/// An appender that writes log records that can be captured by a test
+/// harness such as `cargo test` such that they are suppressed unless
+/// `--nocapture` or `--show-output` is used.
+///
+/// # Examples
+///
+/// ```
+/// use logforth::append::Test;
+///
+/// let test_appender = Test::default();
+/// ```
+#[derive(Debug)]
+pub struct Test {
+    layout: Box<dyn Layout>,
+}
+
+impl Default for Test {
+    fn default() -> Self {
+        Self {
+            layout: Box::new(TextLayout::default()),
+        }
+    }
+}
+
+impl Test {
+    /// Sets the layout for the [`Test`] appender.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use logforth::append::Test;
+    /// use logforth::layout::TextLayout;
+    ///
+    /// let test_appender = Test::default().with_layout(TextLayout::default());
+    /// ```
+    pub fn with_layout(mut self, layout: impl Into<Box<dyn Layout>>) -> Self {
+        self.layout = layout.into();
+        self
+    }
+}
+
+impl Append for Test {
+    fn append(&self, record: &Record, diagnostics: &[Box<dyn Diagnostic>]) -> anyhow::Result<()> {
+        let bytes = self.layout.format(record, diagnostics)?;
+        eprintln!("{}", String::from_utf8_lossy(&bytes));
+        Ok(())
+    }
+
+    fn flush(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
For use in tests to allow test harnesses to capture the log output.