### PR TITLE
refactor: rolling log file name pattern as yyyy-mm-dd.log.n

### DIFF
--- a/src/append/rolling_file/rolling.rs
+++ b/src/append/rolling_file/rolling.rs
@@ -337,16 +337,16 @@ impl State {
 
 #[cfg(test)]
 mod tests {
-    use std::cmp::min;
-    use std::fs;
-    use std::io::Write;
-    use std::ops::Add;
-    use std::str::FromStr;
-
     use jiff::Span;
     use jiff::Zoned;
     use rand::distr::Alphanumeric;
     use rand::Rng;
+    use std::cmp::min;
+    use std::io::Write;
+    use std::ops::Add;
+    use std::str::FromStr;
+    use std::time::Duration;
+    use std::{fs, thread};
     use tempfile::TempDir;
 
     use crate::append::rolling_file::clock::Clock;
@@ -448,6 +448,7 @@ mod tests {
             }
 
             writer.flush().unwrap();
+            thread::sleep(Duration::from_millis(100));
             assert_eq!(
                 fs::read_dir(&writer.state.log_dir).unwrap().count(),
                 min(i, max_files)

--- a/src/append/rolling_file/rolling.rs
+++ b/src/append/rolling_file/rolling.rs
@@ -218,9 +218,9 @@ impl State {
                 format!("{filename}.{cnt}.{suffix}")
             }
             (&Rotation::Never, None, Some(suffix)) => format!("{cnt}.{suffix}"),
-            (_, Some(filename), Some(suffix)) => format!("{filename}.{date}.{cnt}.{suffix}"),
+            (_, Some(filename), Some(suffix)) => format!("{filename}.{date}.{suffix}.{cnt}"),
             (_, Some(filename), None) => format!("{filename}.{date}.{cnt}"),
-            (_, None, Some(suffix)) => format!("{date}.{cnt}.{suffix}"),
+            (_, None, Some(suffix)) => format!("{date}.{suffix}.{cnt}"),
             (_, None, None) => format!("{date}.{cnt}"),
         }
     }


### PR DESCRIPTION
Fixes #143  