### PR TITLE
test: ensure fastrace diags provide proper context

### DIFF
--- a/diagnostics/fastrace/Cargo.toml
+++ b/diagnostics/fastrace/Cargo.toml
@@ -35,5 +35,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 fastrace = { workspace = true }
 logforth-core = { workspace = true }
 
+[dev-dependencies]
+fastrace = { workspace = true, features = ["enable"] }
+
 [lints]
 workspace = true


### PR DESCRIPTION
For 915762093e96a522e1320dc559442f8ecad7f0b1