### PR TITLE
fix: ensure async flush waits for completion

### DIFF
--- a/appenders/async/src/lib.rs
+++ b/appenders/async/src/lib.rs
@@ -19,6 +19,7 @@
 use std::sync::Arc;
 
 use logforth_core::Append;
+use logforth_core::Error;
 use logforth_core::kv;
 use logforth_core::record::RecordOwned;
 
@@ -37,6 +38,7 @@ enum Task {
     },
     Flush {
         appends: Arc<[Box<dyn Append>]>,
+        completion: crossbeam_channel::Sender<Result<(), Error>>,
     },
 }
 


### PR DESCRIPTION
## Summary
- ensure async flush waits for worker completion
- propagate the first flush error back to caller
- add regression tests for blocking flush and error propagation