### PR TITLE
chore: no need arc-swap then

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,6 @@ logforth-layout-text = { version = "0.3.0", path = "layouts/text" }
 
 # Crates.io dependencies
 anyhow = { version = "1.0" }
-arc-swap = { version = "1.7.1" }
 clap = { version = "4.5.49", features = ["derive"] }
 colored = { version = "3.0" }
 fastrace = { version = "0.7" }

--- a/appenders/async/Cargo.toml
+++ b/appenders/async/Cargo.toml
@@ -32,7 +32,6 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-arc-swap = { workspace = true }
 logforth-core = { workspace = true }
 oneshot = { workspace = true }
 


### PR DESCRIPTION
After #208 we can take `&mut self` when handling destory now. No longer needs the `arc-swap` dep for interior mutability.