### PR TITLE
docs: Add a per-module log level config example

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -109,6 +109,12 @@ name = "custom_layout_filter"
 path = "src/custom_layout_filter.rs"
 required-features = ["starter-log"]
 
+
+[[example]]
+name = "per_module_log_levels"
+path = "src/per_module_log_levels.rs"
+required-features = ["starter-log"]
+
 [[example]]
 name = "syslog"
 path = "src/syslog.rs"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -109,7 +109,6 @@ name = "custom_layout_filter"
 path = "src/custom_layout_filter.rs"
 required-features = ["starter-log"]
 
-
 [[example]]
 name = "per_module_log_levels"
 path = "src/per_module_log_levels.rs"

--- a/examples/src/per_module_log_levels.rs
+++ b/examples/src/per_module_log_levels.rs
@@ -1,0 +1,45 @@
+// Copyright 2024 FastLabs Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use logforth::append;
+use logforth::filter::env_filter::EnvFilterBuilder;
+use logforth::record::Level;
+use logforth::record::LevelFilter;
+
+fn main() {
+    // This is how you can allow trace level logs for everything else while silencing them
+    // for the ones you probably don't need (in this case various rerun modules).
+    let my_filter = EnvFilterBuilder::from_default_env()
+        .filter_level(LevelFilter::MoreSevereEqual(logforth::record::Level::Trace))
+        .filter_module("rerun", LevelFilter::MoreSevereEqual(Level::Warn))
+        .filter_module("re_chunk", LevelFilter::MoreSevereEqual(Level::Warn))
+        .filter_module("re_log", LevelFilter::MoreSevereEqual(Level::Warn))
+        .filter_module("re_log_encoding", LevelFilter::MoreSevereEqual(Level::Warn))
+        .filter_module("re_sdk", LevelFilter::MoreSevereEqual(Level::Warn))
+        .filter_module("re_sorbet", LevelFilter::MoreSevereEqual(Level::Warn))
+        .filter_module("tracing", LevelFilter::MoreSevereEqual(Level::Warn))
+        .build();
+
+    logforth::starter_log::builder()
+        .dispatch(|d| d.filter(my_filter).append(append::Stdout::default()))
+        .apply();
+
+    {
+        log::error!("Hello error!");
+        log::warn!("Hello warn!");
+        log::info!("Hello info!");
+        log::debug!("Hello debug!");
+        log::trace!("Hello trace!");
+    }
+}

--- a/examples/src/per_module_log_levels.rs
+++ b/examples/src/per_module_log_levels.rs
@@ -35,11 +35,9 @@ fn main() {
         .dispatch(|d| d.filter(my_filter).append(append::Stdout::default()))
         .apply();
 
-    {
-        log::error!("Hello error!");
-        log::warn!("Hello warn!");
-        log::info!("Hello info!");
-        log::debug!("Hello debug!");
-        log::trace!("Hello trace!");
-    }
+    log::error!("Hello error!");
+    log::warn!("Hello warn!");
+    log::info!("Hello info!");
+    log::debug!("Hello debug!");
+    log::trace!("Hello trace!");
 }

--- a/typos.toml
+++ b/typos.toml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 [default.extend-words]
+"controllen" = "controllen" # libc's control_len
 
 [files]
 extend-exclude = []


### PR DESCRIPTION
This closes https://github.com/fast/logforth/issues/219

I tested that it compiles and runs with...

```sh
cargo run --example per_module_log_levels -F starter-log
```

... but since the only logger here is the example itself, you wouldn't know it actually works just by running the example