### PR TITLE
refactor: Derive `Clone` for `RustLogFilter` and `Directive`

### DIFF
--- a/filters/rustlog/src/lib.rs
+++ b/filters/rustlog/src/lib.rs
@@ -101,7 +101,7 @@ pub const DEFAULT_FILTER_ENV: &str = "RUST_LOG";
 /// Read more from the [crate documentation](self) about the directive syntax and use cases.
 ///
 /// [`Record`]: logforth_core::record::Record
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct RustLogFilter {
     directives: Vec<Directive>,
 }
@@ -366,7 +366,7 @@ impl RustLogFilterBuilder {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 struct Directive {
     name: Option<String>,
     level: LevelFilter,


### PR DESCRIPTION
I was writing something using logforth, and instead of using different filters for different appenders [(Like in the example from percas)](https://github.com/scopedb/percas/blob/d01db13b/crates/server/src/telemetry.rs#L131-L227), I wanted to reuse a single filter:

```rs
let filter = RustLogFilterBuilder::try_from_spec(&configuration.filter)?.build();

let mut builder = logforth::starter_log::builder();

// If configured, add an opentelemetry exporter to the logger
if let Some(otlp_config) = &configuration.opentelemetry {
    let appender = {
        let exporter = LogExporter::builder()
            .with_tonic()
            .with_endpoint(&otlp_config.endpoint)
            .with_protocol(Protocol::Grpc)
            .build()?;

        OpentelemetryLogBuilder::new(otlp_config.service_name.clone(), exporter)
            .label("service.name", otlp_config.service_name.clone())
            .build()
    };

    // First filter use
    builder = builder.dispatch(|b| b.filter(filter).append(appender));
};

// If enabled, also log to stderr
if configuration.stderr {
    builder = builder.dispatch(|b| {
        // Can't use that same filter a second time!
        b.filter(filter)
            .append(Stderr::default().with_layout(TextLayout::default()))
    });
}
```

My obvious next step is to `.clone()` the filter, but turns out that isn't implemented. Is there any particluar reason? Am I missing something?